### PR TITLE
Version 1.4.5.23

### DIFF
--- a/Change Log.txt
+++ b/Change Log.txt
@@ -1,3 +1,18 @@
+## 1.4.5.23 ##
+==============
+-- Added display of "OR" quest items for when you have multiple possible objectives but only need to complete 1.
+-- Optional quest notes or optional objectives will be preceeded by "**" and of the optional color.
+-- Cleaned up code that controlled visibility of the tracker
+-- Added option to hide tracker in combat - Keybind to hide tracker will override this.
+
+"OR" display of quests os for quests where you have more than one objective, but only need to complete one.  For example you need to speak to one of two people.  These will show under the "Optional Objectives"  The color will be the optional color, and the quest condition will be lead by two "*".  Once you complete one of the them, it will update to the next phase of the quest.  For Example, *? Talk to Skorvild, the "**" indicats it is "Or" quest stage.
+
+New option to hide tracker in combat will be overriden by the keybind.  That is, if you already selected the keybind to hide the tracker it will not become visibile again until you press the keybind again.  Did this so that the game is making it visible when you want it to be.
+
+I found many issues with the tracker hiding, cleaned up the code and it appears to be functioning correctly.  It should hide when the side menu is opened, the top menu is opened, in any of the character views, when any of the crafting windows are open, including CraftStore crafting windows.  If there is any issues please let me know.
+
+----------------------------------------------------------------------------------------------
+
 ## 1.4.4.23 ##
 ==============
 -- Fixed two registrations of same event.

--- a/FCMQT.lua
+++ b/FCMQT.lua
@@ -1,6 +1,6 @@
 ﻿-- Name    : Fully Customizable MultiQuests Tracker (FCMQT)
 -- Author  : DesertDwellers Original Coding by Black Storm
--- Version : 1.4.4.23
+-- Version : 1.4.5.23
 -- Date    : 2017/09/01
 FCMQT = FCMQT or {}
 
@@ -38,6 +38,7 @@ FCMQT.CyrodiilNumZoneIndex = 37
 
 
 FCMQT.DEBUG = 0
+
 SLASH_COMMANDS["/fcmqt_debug1"] = FCMQT.CMD_DEBUG1
 SLASH_COMMANDS["/fcmqt_debug2"] = FCMQT.CMD_DEBUG2
 SLASH_COMMANDS["/fcmqt_debug3"] = FCMQT.CMD_DEBUG3
@@ -234,20 +235,32 @@ function FCMQT.AddNewContent(qindex, qstep, qtext, mytype, qzone, qfocusedzoneva
 		FCMQT.textbox[FCMQT.boxmarker]:SetHandler()
 	end	
 	local CurrentFocusedQuest = GetTrackedIsAssisted(1,qindex,0)
+	-- Quest conditions/steps assigment of mytype
+	-- 1  = Objective
+	-- 2  = Objective Completed
+	-- 3  = ?? Optional
+	-- 4  = ?? Optional
+	-- 5  = Optional Objective
+	-- 6  = Optional Objective Completed
+	-- 7  = Hint
+	-- 8  = Hint Completed
+	-- 9  = Hidden Hint
+	-- 10 = Hidden Hint Completed
+	
 	if mytype == 2 then
 		FCMQT.textbox[FCMQT.boxmarker]:SetText("*"..qtext)
 		FCMQT.textbox[FCMQT.boxmarker]:SetColor(FCMQT.SavedVars.TextCompleteColor.r, FCMQT.SavedVars.TextCompleteColor.g, FCMQT.SavedVars.TextCompleteColor.b,FCMQT.SavedVars.TextCompleteColor.a)
 	elseif mytype == 3 then
-		FCMQT.textbox[FCMQT.boxmarker]:SetText(FCMQT.mylanguage.quest_optional.." : "..qtext)
+		FCMQT.textbox[FCMQT.boxmarker]:SetText(" ** "..qtext)
 		FCMQT.textbox[FCMQT.boxmarker]:SetColor(FCMQT.SavedVars.TextOptionalColor.r, FCMQT.SavedVars.TextOptionalColor.g, FCMQT.SavedVars.TextOptionalColor.b, FCMQT.SavedVars.TextOptionalColor.a)
 	elseif mytype == 4 then
-		FCMQT.textbox[FCMQT.boxmarker]:SetText(FCMQT.mylanguage.quest_optional.." : "..qtext)
+		FCMQT.textbox[FCMQT.boxmarker]:SetText(" ** "..qtext)
 		FCMQT.textbox[FCMQT.boxmarker]:SetColor(FCMQT.SavedVars.TextOptionalCompleteColor.r, FCMQT.SavedVars.TextOptionalCompleteColor.g, FCMQT.SavedVars.TextOptionalCompleteColor.b, FCMQT.SavedVars.TextOptionalCompleteColor.a)
 	elseif mytype == 5 then
-		FCMQT.textbox[FCMQT.boxmarker]:SetText("**"..qtext)
+		FCMQT.textbox[FCMQT.boxmarker]:SetText(" *? "..qtext)
 		FCMQT.textbox[FCMQT.boxmarker]:SetColor(FCMQT.SavedVars.TextOptionalColor.r, FCMQT.SavedVars.TextOptionalColor.g, FCMQT.SavedVars.TextOptionalColor.b, FCMQT.SavedVars.TextOptionalColor.a)
 	elseif mytype == 6 then
-		FCMQT.textbox[FCMQT.boxmarker]:SetText("**"..qtext)
+		FCMQT.textbox[FCMQT.boxmarker]:SetText(" *? "..qtext)
 		FCMQT.textbox[FCMQT.boxmarker]:SetColor(FCMQT.SavedVars.TextOptionalColor.r, FCMQT.SavedVars.TextOptionalColor.g, FCMQT.SavedVars.TextOptionalColor.b, FCMQT.SavedVars.TextOptionalColor.a)
 	elseif mytype == 7 then
 		FCMQT.textbox[FCMQT.boxmarker]:SetText(FCMQT.mylanguage.quest_hint.." : "..qtext)
@@ -324,6 +337,7 @@ function FCMQT.ShowQuestTimer(_timerEnd)
 	EM:RegisterForUpdate("FCMQT_Update_Timer", 10, function() FCMQT.UpdateQuestTime(_timerEnd) end, 10)
 	FCMQT.isTimedQuest = true
 	FCMQT.boxqtimer:SetHidden(false)
+	FCMQT.boxqtimer:SetAlpha(1)
 	FCMQT.UpdateQuestTime(_timerEnd)
 	
 end
@@ -344,7 +358,7 @@ function FCMQT.GetQuestTimer(i)
 		end
 	else
 		FCMQT.isTimedQuest = false
-		FCMQT.boxqtimer:SetHidden(true)
+		--FCMQT.boxqtimer:SetHidden(true)
 	end
 end	
 
@@ -365,14 +379,12 @@ function FCMQT.LoadQuestsInfo(i)
 			local qzone, qobjective, qzoneidx, poiIndex = GetJournalQuestLocationInfo(i)
 			FCMQT.GetQuestTimer(i)
 			if FCMQT.DEBUG == 1 then 
-				d("**QUEST**********************************************************")
-				d("DEBUG "..qname.."  ZoneIndex : "..qzoneidx.." / Zone : "..qzone)
+				d("**QUEST START**********************************************************")
+				d("* Quest : "..qname.."  ZoneIndex : "..qzoneidx.." / Zone : "..qzone)
 				local currentmapidx = GetCurrentMapZoneIndex()
-				d("Player IDX Location: "..currentmapidx)
-				if tracked == true then d("Is Tracked : True")
-				else d("Is Tracked : false")
-				end
-				d("QType : "..qtype.."  backgroundText : "..backgroundText.." / activeStepText : "..activeStepText)
+				d("* Player IDX Location: "..currentmapidx)
+				if tracked == true then d("Is Tracked : True") else d("* Is Tracked : false")end
+				d("* QuestType : "..qtype.."  backgroundText : "..backgroundText.." / activeStepText : "..activeStepText)
 			end
 			-- Collect infos for table sort
 			qzone = #qzone > 0 and zo_strformat(SI_QUEST_JOURNAL_ZONE_FORMAT, qzone) or zo_strformat(SI_QUEST_JOURNAL_GENERAL_CATEGORY)
@@ -403,8 +415,8 @@ function FCMQT.LoadQuestsInfo(i)
 			end
 			-- Debug info focused quest and zone
 			if FCMQT.DEBUG == 1 then 
-				d("Found focused zone "..FCMQT.FocusedZone.." zone idx "..FCMQT.FocusedZoneIdx.."  zoneval "..FCMQT.QuestList[FCMQT.varnumquest].focusedzoneval)
-				if FCMQT.QuestList[FCMQT.varnumquest].focusquest == 1 then d("Focused Quest") else d("Not Focused Quest") end
+				d("* Found focused zone "..FCMQT.FocusedZone.." zone idx "..FCMQT.FocusedZoneIdx.."  zoneval "..FCMQT.QuestList[FCMQT.varnumquest].focusedzoneval)
+				if FCMQT.QuestList[FCMQT.varnumquest].focusquest == 1 then d("* Focused Quest") else d("* Not Focused Quest") end
 			end
 			FCMQT.QuestList[FCMQT.varnumquest].name = qname
 			FCMQT.QuestList[FCMQT.varnumquest].type = qtype
@@ -447,22 +459,34 @@ function FCMQT.LoadQuestsInfo(i)
 					FCMQT.QuestList[FCMQT.varnumquest].myzone = FCMQT.QuestList[FCMQT.varnumquest].myzone.." (TEST)"
 				end
 			end
-			if FCMQT.DEBUG == 1 then d("Zone Name: "..FCMQT.QuestList[FCMQT.varnumquest].zone.."     MyZone Name: "..FCMQT.QuestList[FCMQT.varnumquest].myzone) end
+			if FCMQT.DEBUG == 1 then d("* Zone Name: "..FCMQT.QuestList[FCMQT.varnumquest].zone.."     MyZone Name: "..FCMQT.QuestList[FCMQT.varnumquest].myzone) end
 			-- Quest Steps
 			FCMQT.QuestList[FCMQT.varnumquest].step = {}
 			local k = 1
 			local condcheck2 = {}
 			local nbStep = GetJournalQuestNumSteps(i)
 			if FCMQT.DEBUG == 1 then 
-				d("qtype : "..qtype.." / ActiveStepType : "..activeStepType.. " / nbStep : "..nbStep)
-				d("--END QUEST INFO---Start Steps Info------------")
+				d("* Number of steps: "..nbStep)
+				d("**QUEST END************************************************************")
+				d("+-Steps Info START=====================================================")
 			end
 			for idx=1, nbStep do
-				if FCMQT.DEBUG == 1 then d("***STEP idx "..idx.."***************************************") end
-				if activeStepType == 3 then
+				if FCMQT.DEBUG == 1 then d(": Step idx "..idx.." of nb Steps "..nbStep) end
+				-- If active step 
+				-- 		QUEST_STEP_TYPE_AND 			= 1
+				--		QUEST_STEP_TYPE_BRANCH 			= 4
+				--		QUEST_STEP_TYPE_END 			= 3
+				--		QUEST_STEP_TYPE_ITERATION_BEGIN = 1
+				--		QUEST_STEP_TYPE_ITERATION_END 	= 4
+				--		QUEST_STEP_TYPE_OR = 2
+				if activeStepType == QUEST_STEP_TYPE_END then
 					local goal, dialog, confirmComplete, declineComplete, backgroundText, journalStepText = GetJournalQuestEnding(i)
 					if (goal ~= nil and goal ~= "") then
-						if FCMQT.DEBUG == 1 then d("Step idx "..idx.." -> Goal : "..goal.." Step Type END") end
+						if FCMQT.DEBUG == 1 then 
+							d(": Step idx "..idx.." -> Goal : "..goal.." Step Type = "..activeStepType) 
+							d(":     Background text: "..backgroundText)
+							d(":     Journal Step Text: "..journalStepText)
+						end
 						if not FCMQT.QuestList[FCMQT.varnumquest].step[k] then
 							FCMQT.QuestList[FCMQT.varnumquest].step[k] = {}
 						end
@@ -474,9 +498,15 @@ function FCMQT.LoadQuestsInfo(i)
 					local qstep, visibility, stepType, trackerOverrideText, numConditions = GetJournalQuestStepInfo(i,idx)
 					if (qstep ~= nil) then
 						if FCMQT.DEBUG == 1 then 
-							d("Step"..idx.." type : "..stepType.." 1 AND 2 OR   over : "..trackerOverrideText.." / -> Step : "..qstep)
-						end 
-						if FCMQT.DEBUG == 1 then d("Visibility check and mytype assignments -----------------") end
+							d(": Step idx "..idx.."  Num of Conditions: "..numConditions.." stepType : "..stepType.." AND = 1, BRANCH = 4, OR = 2") 
+							d(":     Tracker OverRide Text: "..trackerOverrideText)
+							if visibility ~= nil then
+								d(":     Visibility: "..visibility.." -- Hidden = 2, Hint = 0, Optional = 1, Nil = Objective")
+							else
+								d(":     Visibility: NIL -- Hidden = 2, Hint = 0, Optional = 1, Nil = Objective")
+							end
+						end
+						if FCMQT.DEBUG == 1 then d("+ My Type Assignements ------------------- -----------------") end
 						if visibility == nil or visibility == QUEST_STEP_VISIBILITY_HINT or visibility == QUEST_STEP_VISIBILITY_OPTIONAL or visibility == QUEST_STEP_VISIBILITY_HIDDEN then
 							--**REMOVE 1.3**if ((visibility == 0 or visibility == 1 or visibility == 2) and FCMQT.HideInfoHintsOption == false) then
 							if ((visibility == nil or visibility == QUEST_STEP_VISIBILITY_HIDDEN or visibility == QUEST_STEP_VISIBILITY_HINT or visibility == QUEST_STEP_VISIBILITY_OPTIONAL) and FCMQT.SavedVars.HideInfoOptionalObjOption == true) then
@@ -495,135 +525,168 @@ function FCMQT.LoadQuestsInfo(i)
 								end
 								FCMQT.QuestList[FCMQT.varnumquest].step[k].text = qstep
 								FCMQT.QuestList[FCMQT.varnumquest].step[k].mytype = mytype
-								-- DEBUG1 Start
 								if FCMQT.DEBUG == 1 then 
-									d("Step Added "..k.." Visibility: "..visibility.."  mytype "..mytype)
-									d("Step text "..qstep)
+									d(":     Step Added "..k.." Visibility: "..visibility.."  mytype "..mytype)
+									d(":     Step text "..qstep.."    stepType "..stepType)
+									d(":     INFO HIDDEN")
+									d(":---------------------------------------------------------------------")
 								end
-								-- DEBUG1 End
 								k = k + 1
 							else
 								local checkstep = ""
-								if FCMQT.DEBUG == 1 then d("Visibiliyt nil   numConditions : "..numConditions) end
+								--Conditions start
 								for m=1, numConditions do
-									if FCMQT.DEBUG == 1 then d("Step num : "..k) end
 									local mytype = 1
 									local conditionText, current, max, isFailCondition, isComplete, isCreditShared = GetJournalQuestConditionInfo(i, idx, m)
+									if FCMQT.DEBUG == 1 then 
+										d(": STEP : "..k.."  Condition: "..m) 
+										if conditionText ~= nil and conditionText ~= "" then
+											d(":    conditionText : "..conditionText) 
+										else
+											d(":    conditionText : NIL/Blank")
+										end
+									end
 									if conditionText ~= nil and conditionText ~= "" then
-										if activeStepType == 2 then
+										-- if it is QUEST_STEP_TYPE_OR active step (2) and current step (idx) > nbStep then break out
+										if activeStepType == QUEST_STEP_TYPE_OR then
 											if idx >= nbStep and idx > 1 then
+												if FCMQT.DEBUG == 1 then d(": !!BREAK!! idx >=nbStep  idx "..idx.."  nbStep: "..nbStep) end
 												break;
 											end
 										end
-										
+										-- checkstep starts as "" so not equal to qstep
+										-- Quest conditions/steps assigment of mytype
+										-- 1  = Objective
+										-- 2  = Objective Completed
+										-- 3  = ?? Optional
+										-- 4  = ?? Optional Completed
+										-- 5  = Optional Objective
+										-- 6  = Optional Objective Completed
+										-- 7  = Hint
+										-- 8  = Hint Completed
+										-- 9  = Hidden Hint
+										-- 10 = Hidden Hint Completed
 										if checkstep ~= qstep then
 											if visibility == QUEST_STEP_VISIBILITY_OPTIONAL then
 											-- Optional quests infos
-												if FCMQT.DEBUG == 1 then d("Cond Added1 vis=1 -- Optional ") end
 												if isComplete ~= true then mytype = 3 else mytype = 4 end
 											-- quests hints infos
 											elseif visibility == QUEST_STEP_VISIBILITY_HINT then
-												if FCMQT.DEBUG == 1 then d("Cond Added1 vis=0 -- Hint ") end
 												if isComplete ~= true then mytype = 7 else mytype = 8 end
 											-- hidden quests hints infos
 											elseif visibility == QUEST_STEP_VISIBILITY_HIDDEN then
-												if FCMQT.DEBUG == 1 then d("Cond Added1 vis=2 -- Hidden ") end
 												if isComplete ~= true then mytype = 9 else mytype = 10 end
 											end
+											-- if anything but nil visibility
 											if visibility == QUEST_STEP_VISIBILITY_OPTIONAL or visibility == QUEST_STEP_VISIBILITY_HINT or visibility == QUEST_STEP_VISIBILITY_HIDDEN then
 												if not FCMQT.QuestList[FCMQT.varnumquest].step[k] then
 													FCMQT.QuestList[FCMQT.varnumquest].step[k] = {}
 												end
 												checkstep = qstep
 												table.insert(condcheck2, qstep)
+												if FCMQT.DEBUG == 1 then d(":     1-table.insert condcheck2,qtext") end
 												FCMQT.QuestList[FCMQT.varnumquest].step[k].text = qstep
 												FCMQT.QuestList[FCMQT.varnumquest].step[k].mytype = mytype
 												-- DEBUG1 Start
 												if FCMQT.DEBUG == 1 then 
-													d("Cond/Step Added "..k.." Visibility: "..visibility.."  mytype "..mytype)
-													d("Cond/Step "..qstep)
+													d(":     Cond/Step Added   k: "..k.." idx: "..idx.." Condition: "..m.." Of NumConditions: "..numConditions.." Visibility: "..visibility)
+													d(":     Cond/Step "..qstep.."  mytype "..mytype)
 												end
 												-- DEBUG1 End
 												k = k + 1
 											end
-											if FCMQT.DEBUG == 1 and visibility == nil then d("Cond/Step Visibility is nil") end
+											if FCMQT.DEBUG == 1 and visibility == nil then 
+												d(":     !!Cond/Step NOT Added   k: "..k.." idx: "..idx.." Condition: "..m.." Of NumConditions: "..numConditions.." Visibility: NIL")
+												d(":     !!Cond/Step "..qstep.."  mytype "..mytype)
+											end
 										end
-										if isComplete ~= true then
-											if FCMQT.DEBUG == 1 then d("Cond num : "..k.." -> Cond : "..conditionText.." / "..current.." / "..max) end
-											if visibility == QUEST_STEP_VISIBILITY_OPTIONAL then
-												mytype = 5
-												if FCMQT.DEBUG == 1 then d("Cond Added vis=1 -- Optional -- myType = "..mytype) end
-											elseif visibility == QUEST_STEP_VISIBILITY_HINT then
-												mytype = 7
-												if FCMQT.DEBUG == 1 then d("Cond Added vis=0 -- Hint -- mytype - "..mytype) end
-											elseif visibility ==QUEST_STEP_VISIBILITY_HIDDEN then
-												mytype = 9
-												if FCMQT.DEBUG == 1 then d("Cond Added vis=2 -- Hidden -- mytype - "..mytype) end
+										if checkstep ~= conditionText then
+											if isComplete ~= true then
+												if visibility == QUEST_STEP_VISIBILITY_OPTIONAL then
+													mytype = 3
+												elseif visibility == QUEST_STEP_VISIBILITY_HINT then
+													mytype = 7
+												elseif visibility ==QUEST_STEP_VISIBILITY_HIDDEN then
+													mytype = 9
+												elseif visibility == nil and stepType == QUEST_STEP_TYPE_OR then
+													mytype = 5
+												else
+													mytype = 1
+												end
+												local conditionTextClean = conditionText:match("TRACKER GOAL TEXT*")
+												local condcheckmulti = true
+												if FCMQT.DEBUG == 1 then 
+													d(":      conditionText :"..conditionText.." Not completed   mytype: "..mytype)
+													if conditionTextClean == nil then d(":     conditionTextClean is NIL") else d(":     conditionTextClean: "..conditionTextClean) end
+												end
+												for key,value in pairs(condcheck2) do
+													--if ((value == conditionText and visibility ~= nil) or (value:find(conditionText, 1, true) and visibility ~= nil) or stepType == 2) then
+													if ((value == conditionText and visibility ~= nil) or (value:find(conditionText, 1, true) and visibility ~= nil)) then
+														condcheckmulti = false
+													end
+												end
+												if conditionTextClean == nil and condcheckmulti == true then
+													if not FCMQT.QuestList[FCMQT.varnumquest].step[k] then
+														FCMQT.QuestList[FCMQT.varnumquest].step[k] = {}
+													end
+													table.insert(condcheck2, conditionText)
+													checkstep = conditionText
+													if FCMQT.DEBUG == 1 then d(":     2-table.insert condcheck2,conditionText") end
+													FCMQT.QuestList[FCMQT.varnumquest].step[k].text = conditionText
+													FCMQT.QuestList[FCMQT.varnumquest].step[k].mytype = mytype
+													k = k + 1
+												end
 											else
-												mytype = 1
-												if FCMQT.DEBUG == 1 then d("Cond Added vis=nil -- Nil -- mytype - "..mytype) end
-											end
-											local conditionTextClean = conditionText:match("TRACKER GOAL TEXT*")
-											local condcheckmulti = true
-											for key,value in pairs(condcheck2) do
-												if ((value == conditionText and visibility ~= nil) or (value:find(conditionText, 1, true) and visibility ~= nil) or stepType == 2) then
-													condcheckmulti = false
+												if visibility == QUEST_STEP_VISIBILITY_OPTIONAL then
+													mytype = 4
+												elseif visibility == QUEST_STEP_VISIBILITY_HINT then
+													mytype = 8
+												elseif visibility == QUEST_STEP_VISIBILITY_HIDDEN then
+													mytype = 10
+												elseif visibility == nil and stepType == QUEST_STEP_TYPE_OR then
+													mytype = 6
+												else
+													mytype = 2
 												end
-											end
-											if conditionTextClean == nil and condcheckmulti == true then
-												if not FCMQT.QuestList[FCMQT.varnumquest].step[k] then
-													FCMQT.QuestList[FCMQT.varnumquest].step[k] = {}
+												local conditionTextClean = conditionText:match("TRACKER GOAL TEXT*")
+												local condcheckmulti = true
+												if FCMQT.DEBUG == 1 then 
+													d(":      conditionText :"..conditionText.." Completed   mytype: "..mytype)
+													if conditionTextClean ~= nil then d(":     conditionTextClean is NIL") else d(":     conditionTextClean: "..conditionTextClean) end
 												end
-												table.insert(condcheck2, conditionText)
-												FCMQT.QuestList[FCMQT.varnumquest].step[k].text = conditionText
-												FCMQT.QuestList[FCMQT.varnumquest].step[k].mytype = mytype
-												k = k + 1
-											end
-										else
-											if FCMQT.DEBUG == 1 then d("Cond num : "..k.." -> Cond Complete : "..conditionText) end
-											if visibility == QUEST_STEP_VISIBILITY_OPTIONAL then
-												mytype = 6
-												if FCMQT.DEBUG == 1 then d("Cond Complete Added vis=1 -- Optional -- mytype - "..mytype) end
-											elseif visibility == QUEST_STEP_VISIBILITY_HINT then
-												mytype = 8
-												if FCMQT.DEBUG == 1 then d("Cond Complete Added vis=0 -- Hint -- mytype - "..mytype) end
-											elseif visibility == QUEST_STEP_VISIBILITY_HIDDEN then
-												mytype = 10
-												if FCMQT.DEBUG == 1 then d("Cond Complete Added vis=2 -- Hidden -- mytype - "..mytype) end
-											else
-												mytype = 2
-												if FCMQT.DEBUG == 1 then d("Cond Complete Added v=nil -- Nil -- mytype - "..mytype) end
-											end
-											local conditionTextClean = conditionText:match("TRACKER GOAL TEXT*")
-											local condcheckmulti = true
-											for key,value in pairs(condcheck2) do
-												if ((value == conditionText and visibility ~= nil) or (value:find(conditionText, 1, true) and visibility ~= nil) or stepType == 2) then
-													condcheckmulti = false
+												for key,value in pairs(condcheck2) do
+													--if ((value == conditionText and visibility ~= nil) or (value:find(conditionText, 1, true) and visibility ~= nil) or stepType == 2) then
+													if ((value == conditionText and visibility ~= nil) or (value:find(conditionText, 1, true) and visibility ~= nil)) then
+														condcheckmulti = false
+													end
 												end
-											end
-											if conditionTextClean == nil and condcheckmulti == true then
-												if not FCMQT.QuestList[FCMQT.varnumquest].step[k] then
-													FCMQT.QuestList[FCMQT.varnumquest].step[k] = {}
+												if conditionTextClean == nil and condcheckmulti == true then
+													if not FCMQT.QuestList[FCMQT.varnumquest].step[k] then
+														FCMQT.QuestList[FCMQT.varnumquest].step[k] = {}
+													end
+													checkstep = conditionText
+													table.insert(condcheck2, conditionText)
+													if FCMQT.DEBUG == 1 then d(":     3-table.insert condcheck2,conditionText") end
+													FCMQT.QuestList[FCMQT.varnumquest].step[k].text = conditionText
+													FCMQT.QuestList[FCMQT.varnumquest].step[k].mytype = mytype
+													k = k + 1
 												end
-												table.insert(condcheck2, conditionText)
-												FCMQT.QuestList[FCMQT.varnumquest].step[k].text = conditionText
-												FCMQT.QuestList[FCMQT.varnumquest].step[k].mytype = mytype
-												k = k + 1
 											end
 										end
 									end
 								end
 							end
-						else
-							if FCMQT.DEBUG == 1 then
+							else
+								if FCMQT.DEBUG == 1 then
 								d("!!!BAD VIS!!!!!")
 								d("Vis Not Valid Step"..idx.." type : "..stepType.." 1 AND 2 OR   over : "..trackerOverrideText.." / -> Step : "..qstep.."  Vis "..visibility)
 							end
 						end
 					end
 				end
+				if FCMQT.DEBUG == 1 then d("+") end
 			end
-		if FCMQT.DEBUG == 1 then d("---STEP END idx ----------------------------------------") end
+		if FCMQT.DEBUG == 1 then d("+-Steps Info End==================================================") end
 		FCMQT.varnumquest = FCMQT.varnumquest + 1
 	end
 end
@@ -1140,6 +1203,7 @@ function FCMQT.Init(eventCode, addOnName)
 		EM:RegisterForEvent("FCMQT", EVENT_QUEST_TIMER_PAUSED, FCMQT.QuestsListUpdate)
 		EM:RegisterForEvent("FCMQT", EVENT_QUEST_LIST_UPDATED, FCMQT.QuestsListUpdate)
 		EM:RegisterForEvent("FCMQT", EVENT_QUEST_CONDITION_COUNTER_CHANGED, FCMQT.QuestsListUpdate)
+		EM:RegisterForEvent("FCMQT", EVENT_PLAYER_COMBAT_STATE, FCMQT.CheckMode)	-- To hide QT when in combat
 			-- Auto Share Quests
 			local PlayerIsGrouped = IsUnitGrouped('player')
 			if PlayerIsGrouped and FCMQT.SavedVars.AutoShare == true and qindex ~= nil then

--- a/FCMQT.txt
+++ b/FCMQT.txt
@@ -1,7 +1,7 @@
 ﻿## Title: FCM Quest Tracker
 ## APIVersion: 100023
 ## Author: DesertDwellers
-## Version: 1.4.4.23
+## Version: 1.4.5.23
 ## OptionalDependsOn: LibAddonMenu-2.0 LibMediaProvider-1.0
 ## SavedVariables: FCMQTSavedVars
 

--- a/Includes/functions.lua
+++ b/Includes/functions.lua
@@ -7,7 +7,7 @@
 FCMQT = FCMQT or {}
 
 -- General Buffer made by Wykkyd : http://wiki.esoui.com/Event_%26_Update_Buffering
--- Version : 1.4.4.23
+-- Version : 1.4.5.23
 local BufferTable = {}
 local function BufferReached(key, buffer)
 if key == nil then return end
@@ -23,31 +23,60 @@ end
 
 -- Check menu witch are opened
 function FCMQT.CheckMode()
+
 	if FCMQT.main then
 		local InteractiveMenuIsHidden = ZO_KeybindStripControl:IsHidden()
 		local GameMenuIsHidden = ZO_GameMenu_InGame:IsHidden()
 		local DialogueIsHidden = ZO_InteractWindow:IsHidden()
 		local JournalIsHidden = ZO_QuestJournal:IsHidden()
+		local HideInCombat = true
+		
 		--checks for craft store
 		ZO_FocusedQuestTrackerPanel:SetHidden(true)
-		local CSRune_isHidden = true
-		local CSCook_isHidden = true
+		--FCMQT.main:SetHidden(false) end
+
 		if CS then
+			local CSRune_isHidden = true
+			local CSCook_isHidden = true
 			--d("CraftStore loaded.")
 			CSRune_isHidden = CraftStoreFixed_Rune:IsHidden()
 			CSCook_isHidden = CraftStoreFixed_Cook:IsHidden()
-		end
-		if CSRune_isHidden == false or CSCook_isHidden == false then
-			FCMQT.main:SetHidden(true)
+			
+			if CSRune_isHidden == false or CSCook_isHidden == false then
+				--FCMQT.bg:ToggleHidden()
+				-- test cs is still working
+				FCMQT.main:SetHidden(true)
+			else
+				--FCMQT.main:SetHidden(false)
+				if InteractiveMenuIsHidden == true and GameMenuIsHidden == true and DialogueIsHidden == true then
+					FCMQT.main:SetHidden(false)
+					if IsUnitInCombat('player') and FCMQT.SavedVars.HideInCombatOption then FCMQT.main:SetHidden(true) else FCMQT.main:SetHidden(false) end
+				elseif InteractiveMenuIsHidden == false or GameMenuIsHidden == false or DialogueIsHidden == false then
+					FCMQT.main:SetHidden(true)
+				end
+			end
 		else
 			if InteractiveMenuIsHidden == true and GameMenuIsHidden == true and DialogueIsHidden == true then
 				FCMQT.main:SetHidden(false)
+				if IsUnitInCombat('player') and FCMQT.SavedVars.HideInCombatOption then FCMQT.main:SetHidden(true) else FCMQT.main:SetHidden(false) end
 			elseif InteractiveMenuIsHidden == false or GameMenuIsHidden == false or DialogueIsHidden == false then
 				FCMQT.main:SetHidden(true)
 			end
 		end
-		if JournalIsHidden == false then
+	end
+end
+		--if JournalIsHidden == false then
 			-- FCMQT.BoxQuestJournal()
+
+
+function FCMQT.CombatState()
+	local FCMQT_isHidden = FCMQT.main:IsHidden()
+	
+	if FCMQT_isHidden == false then
+		if IsUnitInCombat('player') then
+			FCMQT.main:SetHidden(true)
+		else
+			FCMQT.main:SetHidden(false)
 		end
 	end
 end
@@ -112,6 +141,7 @@ function FCMQT.SetPreset(newPreset)
 		FCMQT.SavedVars.Button3 = FCMQT.PresetDefaults.Button3
 		FCMQT.SavedVars.Button4 = FCMQT.PresetDefaults.Button4
 		FCMQT.SavedVars.Button5 = FCMQT.PresetDefaults.Button5
+		FCMQT.SavedVars.HideInCombatOption = FCMQT.PresetDefaults.HideInCombatOption
 		
 		--for i,v pairs(FCMQT.PresetDefaults)
 			--d(v)
@@ -169,6 +199,7 @@ function FCMQT.SetPreset(newPreset)
 		FCMQT.SavedVars.Button3 = FCMQT.preset1.Button3
 		FCMQT.SavedVars.Button4 = FCMQT.preset1.Button4
 		FCMQT.SavedVars.Button5 = FCMQT.preset1.Button5
+		FCMQT.SavedVars.HideInCombatOption = FCMQT.Preset1.HideInCombatOption
 	else
 		-- nothing
 	end
@@ -806,7 +837,14 @@ function FCMQT.SetQuestsShowTimerOption(newOpt)
 	FCMQT.QuestsListUpdate(1)
 end
 
+function FCMQT.GetHideInCombatOption()
+	return FCMQT.SavedVars.HideInCombatOption
+end
 
+function FCMQT.SetHideInCombatOption(newOpt)
+	FCMQT.SavedVars.HideInCombatOption = newOpt
+	FCMQT.QuestsListUpdate(1)
+end
 
 
 function FCMQT.GetHideOptObjective()

--- a/Includes/preset.lua
+++ b/Includes/preset.lua
@@ -1,6 +1,6 @@
 FCMQT = FCMQT or {}
 -- Defaults Vars
--- Version : 1.4.4.23
+-- Version : 1.4.5.23
 FCMQT.defaults = {
 					["position"] = { ["point"]=TOPLEFT, ["relativePoint"]=TOPLEFT, ["offsetX"]=1000, ["offsetY"]=300 },
 					["Language"] = "English",
@@ -89,6 +89,7 @@ FCMQT.defaults = {
 					["HideHiddenOptions"] = true,
 					["HintColor"] = { ["r"]=0.945098, ["g"]=1, ["b"]=0.796078, ["a"]=0.950820 },
 					["HintCompleteColor"] = { ["r"]=0.603922, ["g"]=0.603922, ["b"]=0.603922, ["a"]=0.950820 },
+					["HideInCombatOption"] =false,
 					
 					
 }
@@ -181,7 +182,7 @@ FCMQT.PresetDefaults = {
 					["HideHiddenOptions"] = true,
 					["HintColor"] = { ["r"]=0.945098, ["g"]=1, ["b"]=0.796078, ["a"]=0.950820 },
 					["HintCompleteColor"] = { ["r"]=0.603922, ["g"]=0.603922, ["b"]=0.603922, ["a"]=0.950820 },
-					
+					["HideInCombatOption"] =false,
 }
 
 FCMQT.preset1 = {
@@ -272,5 +273,5 @@ FCMQT.preset1 = {
 					["HideHiddenOptions"] = true,
 					["HintColor"] = { ["r"]=0.945098, ["g"]=1, ["b"]=0.796078, ["a"]=0.950820 },
 					["HintCompleteColor"] = { ["r"]=0.603922, ["g"]=0.603922, ["b"]=0.603922, ["a"]=0.950820 },
-									
+					["HideInCombatOption"] =false,
 }

--- a/Includes/settings.lua
+++ b/Includes/settings.lua
@@ -1,6 +1,6 @@
 FCMQT = FCMQT or {}
 -- Defaults Vars
--- Version : 1.4.4.23
+-- Version : 1.4.5.23
 
 function CreateSettings()
 
@@ -10,7 +10,7 @@ function CreateSettings()
     local LMP   = LibStub("LibMediaProvider-1.0")
 	
 	local QTAuthor = "DesertDwellers"
-	local QTVersion = "1.4.4.23"
+	local QTVersion = "1.4.5.23"
 	local fontList = LMP:List('font')
 	local langList = {"English", "Français", "Deutsch"}
 	local fontStyles = {"normal", "outline", "shadow", "soft-shadow-thick", "soft-shadow-thin", "thick-outline"}
@@ -57,6 +57,13 @@ function CreateSettings()
 				getFunc = FCMQT.GetPreset,
 				setFunc = FCMQT.SetPreset,
 				warning = FCMQT.mylanguage.lang_menu_warn_2,
+			},
+			{--Hide When in Combat
+				type = "checkbox",
+				name = FCMQT.mylanguage.lang_HideInCombat,
+				tooltip = FCMQT.mylanguage.lang_HideInCombat_tip,
+				getFunc = FCMQT.GetHideInCombatOption,
+				setFunc = FCMQT.SetHideInCombatOption,
 			},
 			{--Overall Transparency, if back ground
 				type = "slider",

--- a/Langs/de.lua
+++ b/Langs/de.lua
@@ -10,7 +10,7 @@ FCMQT.language.de = {
 	-- ß = \195\159
 
 	-- Menu
-	-- Version : 1.4.4.23
+	-- Version : 1.4.5.23
 		----Need translations
 	["lang_quests_category_view_settings"] = "Settings for Category Zone View",
 	["lang_class_show_zone"] = "Show zone in Class Category Zone View",
@@ -35,7 +35,8 @@ FCMQT.language.de = {
 	["lang_HintColor_tip"] = "Color for hints for quest",
 	["lang_HintCompleteColor"] = "Quest Hints Completed Color",
 	["lang_HintCompleteColor_tip"] = "Quest hints completed color.",
-	
+	["lang_HideInCombat"] = "Hide tracker when in combat",
+	["lang_HideInCombat_tip"] = "Hide tracker when in combat",
 	
 	
 	

--- a/Langs/fr.lua
+++ b/Langs/fr.lua
@@ -10,7 +10,7 @@ FCMQT.language.fr = {
 	-- û : \195\187
 	
 	-- Menu
-	-- Version : 1.4.4.23
+	-- Version : 1.4.5.23
 	-- Need Transaltions
 	["lang_quests_category_view_settings"] = "Settings for Category Zone View",
 	["lang_class_show_zone"] = "Show zone in Class Category Zone View",
@@ -35,7 +35,8 @@ FCMQT.language.fr = {
 	["lang_HintColor_tip"] = "Color for hints for quest",
 	["lang_HintCompleteColor"] = "Quest Hints Completed Color",
 	["lang_HintCompleteColor_tip"] = "Quest hints completed color.",
-	
+	["lang_HideInCombat"] = "Hide tracker when in combat",
+	["lang_HideInCombat_tip"] = "Hide tracker when in combat",
 	
 	
 	

--- a/Langs/us.lua
+++ b/Langs/us.lua
@@ -1,7 +1,7 @@
 FCMQT.language = {}
 FCMQT.language.us = {
 	-- Menu
-	-- Version : 1.4.4.23
+	-- Version : 1.4.5.23
 	["lang_quests_category_view_settings"] = "Settings for Category Zone View",
 	["lang_class_show_zone"] = "Show zone in Class Category Zone View",
 	["lang_class_show_zone_tip"] = "When using Category Zone View show the zone of the Class quests",
@@ -25,7 +25,8 @@ FCMQT.language.us = {
 	["lang_HintColor_tip"] = "Color for hints for quest",
 	["lang_HintCompleteColor"] = "Quest Hints Completed Color",
 	["lang_HintCompleteColor_tip"] = "Quest hints completed color.",
-
+	["lang_HideInCombat"] = "Hide tracker when in combat",
+	["lang_HideInCombat_tip"] = "Hide tracker when in combat",
 
 	
 	


### PR DESCRIPTION
## 1.4.5.23 ##
==============
-- Added display of "OR" quest items for when you have multiple possible objectives but only need to complete 1.
-- Optional quest notes or optional objectives will be preceeded by "**" and of the optional color.
-- Cleaned up code that controlled visibility of the tracker
-- Added option to hide tracker in combat - Keybind to hide tracker will override this.